### PR TITLE
Updated footer to fix wrapping

### DIFF
--- a/src/components/layout/footer/footer.tsx
+++ b/src/components/layout/footer/footer.tsx
@@ -24,8 +24,8 @@ const Footer: React.FC<FooterProps> = ({ lang }) => {
                 key={link.url}
                 spanLg={1.5}
                 spanMd={1.5}
-                spanSm={3}
-                spanXs={3}
+                spanSm={2}
+                spanXs={2}
                 isNoMarginBottom={true}
               >
                 <a

--- a/src/data/footer-links.ts
+++ b/src/data/footer-links.ts
@@ -34,11 +34,11 @@ export const footerLinks = [
   //   icon: UniswapSmIcon,
   //   url: marketLinks.uniswapInfo.url,
   // },
-  {
-    name: "Medium",
-    icon: MediumSmIcon,
-    url: informationLink.mediumFoundation.url,
-  },
+  // {
+  //   name: "Medium",
+  //   icon: MediumSmIcon,
+  //   url: informationLink.mediumFoundation.url,
+  // },
   // {
   //   name: "CoinGecko",
   //   icon: CoingeckoSmIcon,


### PR DESCRIPTION
This PR updates the columns on the footer in order to prevent wrapping on mobile devices. 